### PR TITLE
Allow missing of optional items, on memory unzipping, some fixes and refactorings

### DIFF
--- a/gtfs_parser/__main__.py
+++ b/gtfs_parser/__main__.py
@@ -53,6 +53,8 @@ def main():
     validate_args(args)
 
     gtfs = GTFS(args.src)
+    if not gtfs:
+        raise RuntimeError("GTFS is not loaded.")
     print("GTFS loaded.")
 
     os.makedirs(args.dst, exist_ok=True)

--- a/gtfs_parser/__main__.py
+++ b/gtfs_parser/__main__.py
@@ -1,9 +1,6 @@
 import json
 import os
-import zipfile
-import tempfile
 import argparse
-import shutil
 
 from .gtfs import GTFS
 from .parse import read_routes, read_stops
@@ -55,19 +52,7 @@ def main():
     args = load_args()
     validate_args(args)
 
-    if args.src.endswith(".zip"):  # TODO: wiser checking
-        print("extracting zipfile...")
-        temp_dir = os.path.join(tempfile.gettempdir(), "gtfs_parser")
-        if os.path.exists(temp_dir):
-            shutil.rmtree(temp_dir)
-        os.mkdir(temp_dir)
-        with zipfile.ZipFile(args.src) as z:
-            z.extractall(temp_dir)
-        output_dir = temp_dir
-    else:
-        output_dir = args.src
-
-    gtfs = GTFS(output_dir)
+    gtfs = GTFS(args.src)
     print("GTFS loaded.")
 
     os.makedirs(args.dst, exist_ok=True)

--- a/gtfs_parser/__main__.py
+++ b/gtfs_parser/__main__.py
@@ -53,8 +53,6 @@ def main():
     validate_args(args)
 
     gtfs = GTFS(args.src)
-    if not gtfs:
-        raise RuntimeError("GTFS is not loaded.")
     print("GTFS loaded.")
 
     os.makedirs(args.dst, exist_ok=True)

--- a/gtfs_parser/aggregate.py
+++ b/gtfs_parser/aggregate.py
@@ -413,17 +413,22 @@ class Aggregator:
             .lower()
         )
 
-        # filter services by day
-        calendar_df = self.gtfs["calendar"].copy()
-        calendar_df = calendar_df.astype({"start_date": int, "end_date": int})
-        calendar_df = calendar_df[calendar_df[day_of_week] == "1"]
-        calendar_df = calendar_df.query(
-            f"start_date <= {int(yyyymmdd)} and {int(yyyymmdd)} <= end_date",
-            engine="python",
-        )
+        # filter services by calendar
+        calendar_df = self.gtfs.get("calendar")
+        if calendar_df is None:
+            # generate an empty series if calendar.txt is missing because it is not required.
+            services_on_a_day = pd.Series(name="service_id", dtype=str)
+        else:
+            calendar_df = calendar_df.copy()
+            calendar_df = calendar_df.astype({"start_date": int, "end_date": int})
+            calendar_df = calendar_df[calendar_df[day_of_week] == "1"]
+            calendar_df = calendar_df.query(
+                f"start_date <= {int(yyyymmdd)} and {int(yyyymmdd)} <= end_date",
+                engine="python",
+            )
+            services_on_a_day = calendar_df["service_id"]
 
-        services_on_a_day = calendar_df[["service_id"]]
-
+        # filter services by dates
         calendar_dates_df = self.gtfs.get("calendar_dates")
         if calendar_dates_df is not None:
             filtered = calendar_dates_df[calendar_dates_df["date"] == yyyymmdd][

--- a/gtfs_parser/aggregate.py
+++ b/gtfs_parser/aggregate.py
@@ -45,16 +45,9 @@ class Aggregator:
         """
         # filter stop_times by whether serviced or not
         if yyyymmdd:
-            trips_filtered_by_day = self.__get_trips_on_a_date(yyyymmdd)
-            self.gtfs["stop_times"] = pd.merge(
-                self.gtfs["stop_times"],
-                trips_filtered_by_day,
-                on="trip_id",
-                how="left",
-            )
-            self.gtfs["stop_times"] = self.gtfs["stop_times"][
-                self.gtfs["stop_times"]["service_flag"] == 1
-            ]
+            trip_ids_filtered_by_day = self.__get_trips_on_a_date(yyyymmdd)
+            stop_times_df = self.gtfs["stop_times"]
+            self.gtfs["stop_times"] = stop_times_df[stop_times_df["trip_id"].isin(trip_ids_filtered_by_day)]
 
         # time filter
         if begin_time and end_time:
@@ -164,7 +157,7 @@ class Aggregator:
                 [stop["stop_lon"], stop["stop_lat"]],
             )
 
-        if str(stop["parent_station"]) != "nan":
+        if not pd.isnull(stop["parent_station"]):
             similar_stop_id = stop["parent_station"]
             similar_stop = stops_df[stops_df["stop_id"] == similar_stop_id]
             similar_stop_name = similar_stop[["stop_name"]].iloc[0]
@@ -417,16 +410,15 @@ class Aggregator:
         calendar_df = self.gtfs.get("calendar")
         if calendar_df is None:
             # generate an empty series if calendar.txt is missing because it is not required.
-            services_on_a_day = pd.Series(name="service_id", dtype=str)
+            service_ids_on = pd.Series(name="service_id", dtype=str)
         else:
-            calendar_df = calendar_df.copy()
             calendar_df = calendar_df.astype({"start_date": int, "end_date": int})
             calendar_df = calendar_df[calendar_df[day_of_week] == "1"]
             calendar_df = calendar_df.query(
                 f"start_date <= {int(yyyymmdd)} and {int(yyyymmdd)} <= end_date",
                 engine="python",
             )
-            services_on_a_day = calendar_df["service_id"]
+            service_ids_on = calendar_df["service_id"]
 
         # filter services by dates
         calendar_dates_df = self.gtfs.get("calendar_dates")
@@ -434,24 +426,14 @@ class Aggregator:
             filtered = calendar_dates_df[calendar_dates_df["date"] == yyyymmdd][
                 ["service_id", "exception_type"]
             ]
-            to_be_removed_services = filtered[filtered["exception_type"] == "2"]
-            to_be_appended_services = filtered[filtered["exception_type"] == "1"][
-                ["service_id"]
-            ]
+            to_be_removed_service_ids = filtered[filtered["exception_type"] == "2"]["service_id"]
+            to_be_appended_services_ids = filtered[filtered["exception_type"] == "1"]["service_id"]
 
-            services_on_a_day = pd.merge(
-                services_on_a_day, to_be_removed_services, on="service_id", how="left"
-            )
-            services_on_a_day = services_on_a_day[
-                services_on_a_day["exception_type"] != "2"
-            ]
-            services_on_a_day = pd.concat([services_on_a_day, to_be_appended_services])
-
-        services_on_a_day["service_flag"] = 1
+            service_ids_on = service_ids_on[~service_ids_on.isin(to_be_removed_service_ids)]
+            service_ids_on = pd.concat([service_ids_on, to_be_appended_services_ids])
 
         # filter trips
-        trips_df = self.gtfs["trips"].copy()
-        trip_service = pd.merge(trips_df, services_on_a_day, on="service_id")
-        trip_service = trip_service[trip_service["service_flag"] == 1]
+        trips_df = self.gtfs["trips"]
+        trips_in_services = trips_df[trips_df['service_id'].isin(service_ids_on)]
 
-        return trip_service[["trip_id", "service_flag"]]
+        return trips_in_services["trip_id"]

--- a/gtfs_parser/gtfs.py
+++ b/gtfs_parser/gtfs.py
@@ -7,7 +7,7 @@ import io
 
 def append_table(f: io.BufferedIOBase, table_path: str, table_dfs: dict):
     datatype = os.path.splitext(os.path.basename(table_path))[0]
-    df = pd.read_csv(f, dtype=str)
+    df = pd.read_csv(f, dtype=str, keep_default_na=False, na_values={""})
     table_dfs[datatype] = df
 
 

--- a/gtfs_parser/gtfs.py
+++ b/gtfs_parser/gtfs.py
@@ -11,11 +11,19 @@ def append_table(f: io.BufferedIOBase, table_path: str, table_dfs: dict):
     table_dfs[datatype] = df
 
 
-def GTFS(gtfs_dir: str) -> dict:
+def GTFS(gtfs_path: str) -> dict:
+    """
+    read GTFS file to memory.
+
+    Args:
+        path of zip file or directory containing txt files.
+    Returns:
+        dict: tables
+    """
     tables = {}
-    path = os.path.join(gtfs_dir)
+    path = os.path.join(gtfs_path)
     if os.path.isdir(path):
-        table_files = glob.glob(os.path.join(gtfs_dir, "*.txt"))
+        table_files = glob.glob(os.path.join(gtfs_path, "*.txt"))
         for table_file in table_files:
             with open(table_file, encoding="utf-8_sig") as f:
                 append_table(f, table_file, tables)

--- a/gtfs_parser/gtfs.py
+++ b/gtfs_parser/gtfs.py
@@ -48,15 +48,15 @@ def GTFS(gtfs_dir: str) -> dict:
             tables[table] = tables[table].astype(casts)
 
     # Set null values on optional columns used in this module.
-    null_columns = {
-        "stops": {"parent_station"},
-        "agency": {"agency_id"},
-        "routes": {"agency_id"},
-    }
-    for table, columns in null_columns.items():
-        if table in tables:
-            for col in columns:
-                if col not in tables[table].columns:
-                    tables[table][col] = None
+    if "parent_station" not in tables["stops"].columns:
+        tables["stops"]["parent_station"] = None
+
+    # set agency_id when there is a single agency
+    agency_df = tables["agency"]
+    if len(agency_df) == 1:
+        if "agency_id" not in agency_df.columns or pd.isnull(agency_df["agency_id"].iloc[0]):
+            agency_df["agency_id"] = ""
+        agency_id = agency_df['agency_id'].iloc[0]
+        tables["routes"]["agency_id"] = agency_id
 
     return tables

--- a/gtfs_parser/gtfs.py
+++ b/gtfs_parser/gtfs.py
@@ -26,12 +26,23 @@ def GTFS(gtfs_dir: str) -> dict:
         try:
             with zipfile.ZipFile(path) as z:
                 for file_name in z.namelist():
-                    if file_name.endswith(".txt"):
+                    if file_name.endswith(".txt") and os.path.basename(file_name) == file_name:
                         with z.open(file_name) as f:
                             append_table(f, file_name, tables)
         except Exception as e:
             print(f"zip file read error. ({path}: {str(e)})")
             return None
+
+    # check files.
+    if len(tables) == 0:
+        print("txt files must reside at the root level directly, not in a sub folder.")
+        return None
+
+    required_tables = {"agency", "stops", "routes", "trips", "stop_times"}
+    missing_tables = [req for req in required_tables if req not in tables]
+    if len(missing_tables) > 0:
+        print(f"there are missing required files({','.join(missing_tables)}).")
+        return None
 
     # cast some numeric columns from str to numeric
     tables["stops"] = tables["stops"].astype({"stop_lon": float, "stop_lat": float})

--- a/gtfs_parser/gtfs.py
+++ b/gtfs_parser/gtfs.py
@@ -44,13 +44,18 @@ def GTFS(gtfs_dir: str) -> dict:
         print(f"there are missing required files({','.join(missing_tables)}).")
         return None
 
-    # cast some numeric columns from str to numeric
-    tables["stops"] = tables["stops"].astype({"stop_lon": float, "stop_lat": float})
-    tables["stop_times"] = tables["stop_times"].astype({"stop_sequence": int})
-    if tables.get("shapes") is not None:
-        tables["shapes"] = tables["shapes"].astype(
-            {"shape_pt_lon": float, "shape_pt_lat": float, "shape_pt_sequence": int}
-        )
+    # cast some columns
+    cast_columns = {
+        "stops": {"stop_lon": float, "stop_lat": float},
+        "stop_times": {"stop_sequence": int},
+        "shapes": {"shape_pt_lon": float, "shape_pt_lat": float, "shape_pt_sequence": int},
+        "calendar": {"service_id": str},
+        "calendar_dates": {"service_id": str},
+        "trips": {"service_id": str},
+    }
+    for table, casts in cast_columns.items():
+        if table in tables:
+            tables[table] = tables[table].astype(casts)
 
     # Set null values on optional columns used in this module.
     null_columns = {

--- a/gtfs_parser/gtfs.py
+++ b/gtfs_parser/gtfs.py
@@ -61,6 +61,7 @@ def GTFS(gtfs_dir: str) -> dict:
     null_columns = {
         ("stops", "parent_station"): "nan",
         ("agency", "agency_id"): None,
+        ("routes", "agency_id"): None,
     }
     for key, value in null_columns.items():
         table, col = key

--- a/gtfs_parser/gtfs.py
+++ b/gtfs_parser/gtfs.py
@@ -41,9 +41,14 @@ def GTFS(gtfs_dir: str) -> dict:
             {"shape_pt_lon": float, "shape_pt_lat": float, "shape_pt_sequence": int}
         )
 
-    # parent_station is optional column on GTFS but use in this module
-    # when parent_station is not in stops, fill by 'nan' (not NaN)
-    if "parent_station" not in tables.get("stops").columns:
-        tables["stops"]["parent_station"] = "nan"
+    # Set null values on optional columns used in this module.
+    null_columns = {
+        ("stops", "parent_station"): "nan",
+        ("agency", "agency_id"): None,
+    }
+    for key, value in null_columns.items():
+        table, col = key
+        if table in tables and col not in tables[table].columns:
+            tables[table][col] = value
 
     return tables

--- a/gtfs_parser/gtfs.py
+++ b/gtfs_parser/gtfs.py
@@ -8,9 +8,6 @@ import io
 def append_table(f: io.BufferedIOBase, table_path: str, table_dfs: dict):
     datatype = os.path.splitext(os.path.basename(table_path))[0]
     df = pd.read_csv(f, dtype=str)
-    if len(df) == 0:
-        print(f"{datatype}.txt is empty, skipping...")
-        pass
     table_dfs[datatype] = df
 
 
@@ -23,6 +20,9 @@ def GTFS(gtfs_dir: str) -> dict:
             with open(table_file, encoding="utf-8_sig") as f:
                 append_table(f, table_file, tables)
     else:
+        if not os.path.isfile(path):
+            print(f"zip file not found. ({path})")
+            return None
         try:
             with zipfile.ZipFile(path) as z:
                 for file_name in z.namelist():
@@ -30,8 +30,8 @@ def GTFS(gtfs_dir: str) -> dict:
                         with z.open(file_name) as f:
                             append_table(f, file_name, tables)
         except Exception as e:
-            print(f"zip file read error({path}: {str(e)}")
-            raise e
+            print(f"zip file read error. ({path}: {str(e)})")
+            return None
 
     # cast some numeric columns from str to numeric
     tables["stops"] = tables["stops"].astype({"stop_lon": float, "stop_lat": float})

--- a/gtfs_parser/gtfs.py
+++ b/gtfs_parser/gtfs.py
@@ -21,28 +21,21 @@ def GTFS(gtfs_dir: str) -> dict:
                 append_table(f, table_file, tables)
     else:
         if not os.path.isfile(path):
-            print(f"zip file not found. ({path})")
-            return None
-        try:
-            with zipfile.ZipFile(path) as z:
-                for file_name in z.namelist():
-                    if file_name.endswith(".txt") and os.path.basename(file_name) == file_name:
-                        with z.open(file_name) as f:
-                            append_table(f, file_name, tables)
-        except Exception as e:
-            print(f"zip file read error. ({path}: {str(e)})")
-            return None
+            raise FileNotFoundError(f"zip file not found. ({path})")
+        with zipfile.ZipFile(path) as z:
+            for file_name in z.namelist():
+                if file_name.endswith(".txt") and os.path.basename(file_name) == file_name:
+                    with z.open(file_name) as f:
+                        append_table(f, file_name, tables)
 
     # check files.
     if len(tables) == 0:
-        print("txt files must reside at the root level directly, not in a sub folder.")
-        return None
+        raise FileNotFoundError("txt files must reside at the root level directly, not in a sub folder.")
 
     required_tables = {"agency", "stops", "routes", "trips", "stop_times"}
     missing_tables = [req for req in required_tables if req not in tables]
     if len(missing_tables) > 0:
-        print(f"there are missing required files({','.join(missing_tables)}).")
-        return None
+        raise FileNotFoundError(f"there are missing required files({','.join(missing_tables)}).")
 
     # cast some columns
     cast_columns = {

--- a/gtfs_parser/gtfs.py
+++ b/gtfs_parser/gtfs.py
@@ -1,20 +1,36 @@
 import glob
 import os
-
+import zipfile
 import pandas as pd
+import io
+
+
+def append_table(f: io.BufferedIOBase, table_path: str, table_dfs: dict):
+    datatype = os.path.splitext(os.path.basename(table_path))[0]
+    df = pd.read_csv(f, dtype=str)
+    if len(df) == 0:
+        print(f"{datatype}.txt is empty, skipping...")
+        pass
+    table_dfs[datatype] = df
 
 
 def GTFS(gtfs_dir: str) -> dict:
     tables = {}
-    table_files = glob.glob(os.path.join(gtfs_dir, "*.txt"))
-    for table_file in table_files:
-        datatype = os.path.basename(table_file).split(".")[0]
-        with open(table_file, encoding="utf-8_sig") as f:
-            df = pd.read_csv(f, dtype=str)
-            if len(df) == 0:
-                print(f"{datatype}.txt is empty, skipping...")
-                continue
-            tables[datatype] = df
+    path = os.path.join(gtfs_dir)
+    if os.path.isdir(path):
+        table_files = glob.glob(os.path.join(gtfs_dir, "*.txt"))
+        for table_file in table_files:
+            with open(table_file, encoding="utf-8_sig") as f:
+                append_table(f, table_file, tables)
+    else:
+        try:
+            with zipfile.ZipFile(path) as z:
+                for file_name in z.namelist():
+                    with z.open(file_name) as f:
+                        append_table(f, file_name, tables)
+        except Exception as e:
+            print(f"zip file read error({path}: {str(e)}")
+            raise e
 
     # cast some numeric columns from str to numeric
     tables["stops"] = tables["stops"].astype({"stop_lon": float, "stop_lat": float})

--- a/gtfs_parser/gtfs.py
+++ b/gtfs_parser/gtfs.py
@@ -42,9 +42,6 @@ def GTFS(gtfs_dir: str) -> dict:
         "stops": {"stop_lon": float, "stop_lat": float},
         "stop_times": {"stop_sequence": int},
         "shapes": {"shape_pt_lon": float, "shape_pt_lat": float, "shape_pt_sequence": int},
-        "calendar": {"service_id": str},
-        "calendar_dates": {"service_id": str},
-        "trips": {"service_id": str},
     }
     for table, casts in cast_columns.items():
         if table in tables:
@@ -52,13 +49,14 @@ def GTFS(gtfs_dir: str) -> dict:
 
     # Set null values on optional columns used in this module.
     null_columns = {
-        ("stops", "parent_station"): "nan",
-        ("agency", "agency_id"): None,
-        ("routes", "agency_id"): None,
+        "stops": {"parent_station"},
+        "agency": {"agency_id"},
+        "routes": {"agency_id"},
     }
-    for key, value in null_columns.items():
-        table, col = key
-        if table in tables and col not in tables[table].columns:
-            tables[table][col] = value
+    for table, columns in null_columns.items():
+        if table in tables:
+            for col in columns:
+                if col not in tables[table].columns:
+                    tables[table][col] = None
 
     return tables

--- a/gtfs_parser/gtfs.py
+++ b/gtfs_parser/gtfs.py
@@ -26,8 +26,9 @@ def GTFS(gtfs_dir: str) -> dict:
         try:
             with zipfile.ZipFile(path) as z:
                 for file_name in z.namelist():
-                    with z.open(file_name) as f:
-                        append_table(f, file_name, tables)
+                    if file_name.endswith(".txt"):
+                        with z.open(file_name) as f:
+                            append_table(f, file_name, tables)
         except Exception as e:
             print(f"zip file read error({path}: {str(e)}")
             raise e


### PR DESCRIPTION
### Close Issues
* Allow missing of optional items
  * no file of calendar.txt: MIERUNE/GTFS-GO#68, MIERUNE/GTFS-GO#21
  * no field of routes.txt.agency_id: MIERUNE/GTFS-GO#69
  * no record in calendar.txt: MIERUNE/GTFS-GO#70
* Add FileNotFound message
  * Sub folder: MIERUNE/GTFS-GO#75
* Read NaN-like strings as valid values instead of NaN
  * "null": MIERUNE/GTFS-GO#70 

### Description

#### Allow missing of optional items.
* Purpose
  * Support a wider variety of GTFS data
  * Items allowed to be missing
    * files: calendar.txt
    * fields: agency_id@routes.txt, agency.txt
    * record: calendar.txt
* Changes
  * GTFS() set NaN values if the items are missing. 

#### Process zip files on memory without extracting them into directories
* Purpose
  * Save storage space
  * Simplify usage
  * Reduce processing time
* Changes
  * GTFS() takes a zip file path as the argument and internally decompresses the files on memory
  * still accepts directories

#### Add FileNotFound message
* Purpose 
  * To make it easier for users to recognize the cause of the error and the solution to it
* Changes
  * GTFS() raise exceptions.

#### Read NaN-like strings as valid values instead of NaN
* Purpose
  * Fix error when NaN-like strings are included in the field to be used.
    * NaN-like strings are "null", " ", etc.
* Changes
  * Set parameters to pd.read_csv().

#### Refactoring
* Changed NaN value of parent_station from "nan" to None.
* Changed the casting process for GTFS field types.
* Removed useless data copying in __get_trips_on_a_date().
* Changed a single column data frame to a series in In __get_trips_on_a_date().


### Manual Testing
* Allow missing of optional items
  * no file of calendar.txt: MIERUNE/GTFS-GO#21
    * https://github.com/MIERUNE/GTFS-GO/files/5955822/6_repaired_zipped.zip , don't unify stops because of data error in parent_station.
  * no field of routes.txt.agency_id: MIERUNE/GTFS-GO#69
    * https://transitfeeds.com/p/transports-metropolitans-de-barcelona-tmb/995/latest/download)
  * no record in calendar.txt: MIERUNE/GTFS-GO#70
    * https://github.com/MIERUNE/GTFS-GO/files/11573006/gtfs_compressed.zip , extract zip in zip.
* Add FileNotFound message
  * Sub folder: MIERUNE/GTFS-GO#75
    * https://github.com/MIERUNE/GTFS-GO/files/14998967/GTFS_GLTC.zip
* Read NaN-like strings as valid values instead of NaN
  * "null": MIERUNE/GTFS-GO#70 
    * https://github.com/MIERUNE/GTFS-GO/files/11573006/gtfs_compressed.zip , extract zip in zip, check unify stops.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - GTFSファイルの入力処理を簡素化し、ソースディレクトリを直接渡すように変更しました。
- **バグ修正**
  - 異なる停留所を集約する処理で、フィルタリングロジックを改善しました。
  - `calendar.txt`が存在しない場合の処理を追加し、サービスと日付のフィルタリングロジックをリファクタリングしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->