### PR TITLE
Accelerate aggregation and parse

### DIFF
--- a/gtfs_parser/aggregate.py
+++ b/gtfs_parser/aggregate.py
@@ -1,4 +1,3 @@
-from functools import lru_cache
 import datetime
 
 import pandas as pd
@@ -6,11 +5,20 @@ import pandas as pd
 from .gtfs import GTFS
 
 
-def latlon_to_str(latlon):
-    return "".join(list(map(lambda coord: str(round(coord, 4)), latlon)))
-
-
 class Aggregator:
+    """
+    Read stops "interpolated" by parent station or stop_id or stop_name and distance.
+    There are many similar stops that are near to each, has same name, or has same prefix in stop_id.
+    In traffic analyzing, it is good for that similar stops to be grouped as same stop.
+    This method group them by some elements, parent, id, name and distance.
+
+    Args:
+        delimiter (str, optional): stop_id delimiter, sample_A, sample_B, then delimiter is '_'. Defaults to ''.
+        max_distance_degree (float, optional): distance limit in grouping by stop_name. Defaults to 0.01.
+
+    Returns:
+        [type]: [description]
+    """
     def __init__(
         self,
         gtfs: GTFS,
@@ -22,239 +30,167 @@ class Aggregator:
         end_time="",
     ):
         self.gtfs = gtfs
-        self.similar_stops_df = None
 
-        self.__aggregate_similar_stops(
-            delimiter,
-            max_distance_degree,
-            no_unify_stops,
-            yyyymmdd=yyyymmdd,
-            begin_time=begin_time,
-            end_time=end_time,
-        )
+        self.stop_times = Aggregator.__filter_stop_times(self.gtfs, yyyymmdd, begin_time, end_time)
 
-    def __aggregate_similar_stops(
-        self,
-        delimiter: str,
-        max_distance_degree: float,
-        no_unify_stops: bool,
-        yyyymmdd="",
-        begin_time="",
-        end_time="",
-    ):
-        """
-        this method occurs side-effect to modify self.gtfs and self.similar_stops_df
-        """
+        if no_unify_stops:
+            similar_results = Aggregator.__get_similar_stop_without_unifying(self.gtfs.stops)
+        else:
+            similar_results = Aggregator.__unify_similar_stops(self.gtfs.stops, delimiter, max_distance_degree)
+        self.similar_stops, self.stop_relations = similar_results
+
+    @staticmethod
+    def __filter_stop_times(gtfs, yyyymmdd, begin_time, end_time):
         # filter stop_times by whether serviced or not
         if yyyymmdd:
-            trip_ids_filtered_by_day = self.__get_trips_on_a_date(yyyymmdd)
-            self.gtfs.stop_times = self.gtfs.stop_times[
-                self.gtfs.stop_times["trip_id"].isin(trip_ids_filtered_by_day)
+            trip_ids_filtered_by_day = Aggregator.__get_trips_on_a_date(gtfs, yyyymmdd)
+            filtered_stop_times = gtfs.stop_times[
+                gtfs.stop_times["trip_id"].isin(trip_ids_filtered_by_day)
             ]
-
+        else:
+            filtered_stop_times = gtfs.stop_times.copy()
         # time filter
         if begin_time and end_time:
             # departure_time is nullable and expressed in "hh:mm:ss" or "h:mm:ss" format.
             # Hour can be mor than 24.
             # Therefore, drop null records and convert times to integers.
-            int_dep_times = self.gtfs.stop_times.departure_time.str.replace(
+            filtered_stop_times = filtered_stop_times[~filtered_stop_times["departure_time"].isnull()]
+            int_dep_times = filtered_stop_times.departure_time.str.replace(
                 ":", ""
             ).astype(int)
-            self.gtfs.stop_times = self.gtfs.stop_times[
-                self.gtfs.stop_times.departure_time != ""
-            ][(int_dep_times >= int(begin_time)) & (int_dep_times < int(end_time))]
+            filtered_stop_times = filtered_stop_times[(int_dep_times >= int(begin_time))
+                                                      & (int_dep_times < int(end_time))]
+        return filtered_stop_times
 
-        if no_unify_stops:
-            # no unifying stops
-            self.gtfs.stops["similar_stop_id"] = self.gtfs.stops["stop_id"]
-            self.gtfs.stops["similar_stop_name"] = self.gtfs.stops["stop_name"]
-            self.gtfs.stops["similar_stops_centroid"] = self.gtfs.stops[
-                ["stop_lon", "stop_lat"]
-            ].values.tolist()
-            self.gtfs.stops["position_count"] = 1
-            self.similar_stops_df = self.gtfs.stops[
-                [
-                    "similar_stop_id",
-                    "similar_stop_name",
-                    "similar_stops_centroid",
-                    "position_count",
-                ]
-            ].copy()
+    @staticmethod
+    def __get_similar_stop_without_unifying(stops):
+        similar_stops_centroid = stops[["stop_lon", "stop_lat"]].values.tolist()
+
+        similar_stops = pd.DataFrame({
+            "similar_stop_id": stops["stop_id"],
+            "similar_stop_name": stops["stop_name"],
+            "similar_stops_centroid": similar_stops_centroid,
+        })
+        similar_relations = pd.concat([
+            stops["stop_id"],
+            similar_stops["similar_stop_id"]
+        ], axis=1)
+        return similar_stops, similar_relations
+
+    @staticmethod
+    def __unify_similar_stops(stops, delimiter, max_distance_degree):
+        child_similar_stop = None
+        child_id_pair = None
+
+        # unify by parent_station
+        if "location_type" in stops.columns:
+            child_similar_stop, child_id_pair = Aggregator.__unify_child_stops(stops)
+
+            solo_stops = stops[
+                ~stops["stop_id"].isin(child_id_pair["stop_id"])
+                & ~(stops["location_type"] == "1")
+            ]
         else:
-            parent_ids = self.gtfs.stops["parent_station"].unique()
-            self.gtfs.stops["is_parent"] = self.gtfs.stops["stop_id"].map(
-                lambda stop_id: 1 if stop_id in parent_ids else 0
-            )
+            solo_stops = stops
 
-            self.gtfs.stops[
-                ["similar_stop_id", "similar_stop_name", "similar_stops_centroid"]
-            ] = (
-                self.gtfs.stops["stop_id"]
-                .map(
-                    lambda stop_id: self.__get_similar_stop_tuple(
-                        stop_id, delimiter, max_distance_degree
-                    )
-                )
-                .apply(pd.Series)
-            )
-            self.gtfs.stops["position_id"] = self.gtfs.stops[
-                "similar_stops_centroid"
-            ].map(latlon_to_str)
-            self.gtfs.stops["unique_id"] = (
-                self.gtfs.stops["similar_stop_id"] + self.gtfs.stops["position_id"]
-            )
+        # unify solo stops
+        solo_similar_stops, solo_id_pair = Aggregator.__unify_solo_stops(solo_stops, delimiter, max_distance_degree)
 
-            # sometimes stop_name accidently becomes pd.Series instead of str.
-            self.gtfs.stops["similar_stop_name"] = self.gtfs.stops[
-                "similar_stop_name"
-            ].map(lambda val: val if type(val) == str else val.stop_name)
-            print(self.gtfs.stops)
-            position_count = (
-                self.gtfs.stop_times.merge(self.gtfs.stops, on="stop_id", how="left")
-                .groupby("position_id")
-                .size()
-                .to_frame()
-                .reset_index()
-            )
-            position_count.columns = ["position_id", "position_count"]
+        # concat similar stops
+        return pd.concat([child_similar_stop, solo_similar_stops]), pd.concat([child_id_pair, solo_id_pair])
 
-            self.similar_stops_df = pd.merge(
-                self.gtfs.stops.drop_duplicates(subset="position_id")[
-                    [
-                        "position_id",
-                        "similar_stop_id",
-                        "similar_stop_name",
-                        "similar_stops_centroid",
-                    ]
-                ],
-                position_count,
-                on="position_id",
-                how="left",
-            )
+    @staticmethod
+    def __unify_child_stops(stops):
+        child_id_pair = stops[stops["parent_station"].isin(stops["stop_id"])][["stop_id", "parent_station"]]
+        child_id_pair.rename(columns={"parent_station": "similar_stop_id"}, inplace=True)
 
-    @lru_cache(maxsize=None)
-    def __get_similar_stop_tuple(
-        self, stop_id: str, delimiter="", max_distance_degree=0.01
-    ):
-        """
-        With one stop_id, group stops by parent, stop_id, or stop_name and each distance.
-        - parent: if stop has parent_station, the 'centroid' is parent_station lat-lon
-        - stop_id: by delimiter seperate stop_id into prefix and suffix, and group stops having same stop_id-prefix
-        - name and distance: group stops by stop_name, excluding stops are far than max_distance_degree
+        similar_ids = child_id_pair["similar_stop_id"].unique()
 
-        Args:
-            stop_id (str): target stop_id
-            max_distance_degree (float, optional): distance limit on grouping, Defaults to 0.01.
-        Returns:
-            str, str, [float, float]: similar_stop_id, similar_stop_name, similar_stops_centroid
-        """
-        stops_df = self.gtfs.stops.sort_values("stop_id")
-        stop = stops_df[stops_df["stop_id"] == stop_id].iloc[0]
+        similar_stops = stops[stops["stop_id"].isin(similar_ids)][["stop_id", "stop_name", "stop_lon", "stop_lat"]]
+        similar_stops["similar_stops_centroid"] = similar_stops[
+            ["stop_lon", "stop_lat"]
+        ].values.tolist()
+        similar_stops.rename(columns={
+            "stop_id": "similar_stop_id",
+            "stop_name": "similar_stop_name",
+        }, inplace=True)
+        similar_stops.drop(columns=["stop_lon", "stop_lat"], inplace=True)
 
-        if stop["is_parent"] == 1:
-            return (
-                stop["stop_id"],
-                stop["stop_name"],
-                [stop["stop_lon"], stop["stop_lat"]],
-            )
+        return similar_stops, child_id_pair
 
-        if not pd.isnull(stop["parent_station"]):
-            similar_stop_id = stop["parent_station"]
-            similar_stop = stops_df[stops_df["stop_id"] == similar_stop_id]
-            similar_stop_name = similar_stop[["stop_name"]].iloc[0]
-            similar_stop_centroid = (
-                similar_stop[["stop_lon", "stop_lat"]].iloc[0].values.tolist()
-            )
-            return similar_stop_id, similar_stop_name, similar_stop_centroid
-
+    @staticmethod
+    def __unify_solo_stops(solo_stops, delimiter, max_distance_degree):
+        delimited_id_pair = []
         if delimiter:
-            stops_df_id_delimited = self.__get_stops_id_delimited(delimiter)
-            stop_id_prefix = stop_id.rsplit(delimiter, 1)[0]
-            if stop_id_prefix != stop_id:
-                similar_stop_id = stop_id_prefix
-                seperated_only_stops = stops_df_id_delimited[
-                    stops_df_id_delimited["delimited"]
-                ]
-                similar_stops = seperated_only_stops[
-                    seperated_only_stops["stop_id_prefix"] == stop_id_prefix
-                ][
-                    [
-                        "stop_name",
-                        "similar_stops_centroid_lon",
-                        "similar_stops_centroid_lat",
-                    ]
-                ]
-                similar_stop_name = similar_stops[["stop_name"]].iloc[0]
-                similar_stop_centroid = similar_stops[
-                    ["similar_stops_centroid_lon", "similar_stops_centroid_lat"]
-                ].values.tolist()[0]
-                return similar_stop_id, similar_stop_name, similar_stop_centroid
+            # unify by delimiter
+            stop_id_delimited = solo_stops["stop_id"].str.split(delimiter).str[0].rename("similar_stop_id")
+            delimited_id_pair = pd.concat([solo_stops["stop_id"], stop_id_delimited], axis=1)[
+                solo_stops["stop_id"] != stop_id_delimited
+            ]
+        if len(delimited_id_pair) == len(solo_stops):
+            solo_id_pair = delimited_id_pair
+        else:
+            # unify by distance
+            if len(delimited_id_pair) > 0:
+                undelimited_stops = solo_stops[solo_stops["stop_id"] != delimited_id_pair["stop_id"]]
             else:
-                # when cannot seperate stop_id, grouping by name and distance
-                stops_df = stops_df_id_delimited[~stops_df_id_delimited["delimited"]]
+                undelimited_stops = solo_stops
+            near_id_pair = Aggregator.__calc_near_id_pair(undelimited_stops, max_distance_degree)
 
-        # grouping by name and distance
-        similar_stops = stops_df[stops_df["stop_name"] == stop["stop_name"]][
-            ["stop_id", "stop_name", "stop_lon", "stop_lat"]
-        ]
-        similar_stops = similar_stops.query(
-            f'(stop_lon - {stop["stop_lon"]}) ** 2 + (stop_lat - {stop["stop_lat"]}) ** 2  < {max_distance_degree ** 2}'
-        )
-        similar_stop_centroid = (
-            similar_stops[["stop_lon", "stop_lat"]].mean().values.tolist()
-        )
-        similar_stop_id = similar_stops["stop_id"].iloc[0]
-        similar_stop_name = stop["stop_name"]
-        return similar_stop_id, similar_stop_name, similar_stop_centroid
+            if len(delimited_id_pair) == 0:
+                solo_id_pair = near_id_pair
+            else:
+                solo_id_pair = pd.concat([delimited_id_pair, near_id_pair])
 
-    @lru_cache(maxsize=None)
-    def __get_stops_id_delimited(self, delimiter: str):
-        stops_df = self.gtfs.stops[
-            ["stop_id", "stop_name", "stop_lon", "stop_lat", "parent_station"]
-        ].copy()
-        stops_df["stop_id_prefix"] = stops_df["stop_id"].map(
-            lambda stop_id: stop_id.rsplit(delimiter, 1)[0]
+        if len(solo_id_pair) == 0:
+            return None, None
+
+        # calc similar stop attributes
+        solo_stops_with_similar = pd.merge(solo_stops, solo_id_pair, on="stop_id")
+        solo_similar_stops = solo_stops_with_similar.groupby("similar_stop_id").agg({
+            'stop_name': 'min',
+            'stop_lon': 'mean',
+            'stop_lat': 'mean'
+        }).reset_index()
+        solo_similar_stops.rename(columns={"stop_name": "similar_stop_name"}, inplace=True)
+        solo_similar_stops["similar_stops_centroid"] = solo_similar_stops[
+            ["stop_lon", "stop_lat"]
+        ].values.tolist()
+        solo_similar_stops.drop(columns=["stop_lon", "stop_lat"], inplace=True)
+        return solo_similar_stops, solo_id_pair
+
+    @staticmethod
+    def __calc_near_id_pair(solo_stops, max_distance_degree):
+        stop_matrix = pd.merge(
+            solo_stops,
+            solo_stops,
+            on="stop_name",
+            suffixes=("", "_r")
         )
-        stops_df["delimited"] = stops_df["stop_id"] != stops_df["stop_id_prefix"]
-        grouped_by_prefix = (
-            stops_df[["stop_id_prefix", "stop_lon", "stop_lat"]]
-            .groupby("stop_id_prefix")
-            .mean()
-            .reset_index()
-        )
-        grouped_by_prefix.columns = [
-            "stop_id_prefix",
-            "similar_stops_centroid_lon",
-            "similar_stops_centroid_lat",
+        near_matrix = stop_matrix[
+            (stop_matrix["stop_lon"] - stop_matrix["stop_lon_r"]) ** 2
+            + (stop_matrix["stop_lat"] - stop_matrix["stop_lat_r"]) ** 2
+            <= max_distance_degree ** 2
         ]
-        stops_df_with_centroid = pd.merge(
-            stops_df, grouped_by_prefix, on="stop_id_prefix", how="left"
-        )
-        return stops_df_with_centroid
+
+        near_id_pair = near_matrix[["stop_id", "stop_id_r"]].groupby("stop_id").min().reset_index()
+        near_id_pair.rename(columns={"stop_id_r": "similar_stop_id"}, inplace=True)
+        return near_id_pair
 
     def read_interpolated_stops(self):
-        """
-        Read stops "interpolated" by parent station or stop_id or stop_name and distance.
-        There are many similar stops that are near to each, has same name, or has same prefix in stop_id.
-        In traffic analyzing, it is good for that similar stops to be grouped as same stop.
-        This method group them by some elements, parent, id, name and distance.
+        stop_pass_count = self.stop_times.groupby("stop_id").size().rename("count")
+        stop_pass_count = pd.merge(
+            self.stop_relations,
+            stop_pass_count,
+            on="stop_id",
+            how="left"
+        )
+        similar_pass_count = stop_pass_count.groupby("similar_stop_id").sum("count").astype(int)
+        similar_stop_summary = self.similar_stops.merge(similar_pass_count,
+                                                        on="similar_stop_id")
 
-        Args:
-            delimiter (str, optional): stop_id delimiter, sample_A, sample_B, then delimiter is '_'. Defaults to ''.
-            max_distance_degree (float, optional): distance limit in grouping by stop_name. Defaults to 0.01.
+        stop_dicts = similar_stop_summary.to_dict(orient="records")
 
-        Returns:
-            [type]: [description]
-        """
-
-        stop_dicts = self.similar_stops_df[
-            [
-                "similar_stop_id",
-                "similar_stop_name",
-                "similar_stops_centroid",
-                "position_count",
-            ]
-        ].to_dict(orient="records")
         return [
             {
                 "type": "Feature",
@@ -265,7 +201,7 @@ class Aggregator:
                 "properties": {
                     "similar_stop_name": stop["similar_stop_name"],
                     "similar_stop_id": stop["similar_stop_id"],
-                    "count": stop["position_count"],
+                    "count": stop["count"],
                 },
             }
             for stop in stop_dicts
@@ -284,89 +220,59 @@ class Aggregator:
         Returns:
             [type]: [description]
         """
+        # sort similar stop sequence
         stop_times_df = (
-            self.gtfs.stop_times[
-                ["stop_id", "trip_id", "stop_sequence", "departure_time"]
-            ]
+            self.stop_times[["trip_id", "stop_sequence", "stop_id"]]
             .sort_values(["trip_id", "stop_sequence"])
-            .copy()
         )
-
-        # join agency info)
         stop_times_df = pd.merge(
             stop_times_df,
+            self.stop_relations,
+            on="stop_id"
+        )
+        # append agency_id
+        trip_agency_df = pd.merge(
             self.gtfs.trips[["trip_id", "route_id"]],
-            on="trip_id",
-            how="left",
-        )
-        stop_times_df = pd.merge(
-            stop_times_df,
             self.gtfs.routes[["route_id", "agency_id"]],
-            on="route_id",
-            how="left",
+            on="route_id"
         )
         stop_times_df = pd.merge(
             stop_times_df,
-            self.gtfs.agency[["agency_id", "agency_name"]],
-            on="agency_id",
-            how="left",
+            trip_agency_df,
+            on="trip_id"
         )
-
-        # get prev and next stops_id, stop_name, trip_id
-        stop_times_df = pd.merge(
-            stop_times_df,
-            self.gtfs.stops[
-                [
-                    "stop_id",
-                    "similar_stop_id",
-                    "similar_stop_name",
-                    "similar_stops_centroid",
-                ]
-            ],
-            on="stop_id",
-            how="left",
-        )
-        stop_times_df["prev_stop_id"] = stop_times_df["similar_stop_id"]
-        stop_times_df["prev_trip_id"] = stop_times_df["trip_id"]
-        stop_times_df["prev_stop_name"] = stop_times_df["similar_stop_name"]
-        stop_times_df["prev_similar_stops_centroid"] = stop_times_df[
-            "similar_stops_centroid"
-        ]
+        # generate path by joining next stop_times
         stop_times_df["next_stop_id"] = stop_times_df["similar_stop_id"].shift(-1)
         stop_times_df["next_trip_id"] = stop_times_df["trip_id"].shift(-1)
-        stop_times_df["next_stop_name"] = stop_times_df["similar_stop_name"].shift(-1)
-        stop_times_df["next_similar_stops_centroid"] = stop_times_df[
-            "similar_stops_centroid"
-        ].shift(-1)
+        stop_times_df = stop_times_df[stop_times_df["trip_id"] == stop_times_df["next_trip_id"]]
+        path_df = stop_times_df.rename(columns={"similar_stop_id": "prev_stop_id"})
 
-        # drop last stops (-> stops has no next stop)
-        stop_times_df = stop_times_df.drop(
-            index=stop_times_df.query("prev_trip_id != next_trip_id").index
-        )
+        # count frequency
+        path_freq_sr = path_df.groupby(["agency_id", "prev_stop_id", "next_stop_id"]).size()
+        path_freq_sr.name = "frequency"
+        path_freq_df = path_freq_sr.reset_index()
 
-        # define path_id by prev-stops-centroid and next-stops-centroid
-        stop_times_df["path_id"] = (
-            stop_times_df["prev_stop_id"]
-            + stop_times_df["next_stop_id"]
-            + stop_times_df["prev_similar_stops_centroid"].map(latlon_to_str)
-            + stop_times_df["next_similar_stops_centroid"].map(latlon_to_str)
-        )
+        # append path attributes
+        for order in ["prev", "next"]:
+            path_freq_df = pd.merge(
+                path_freq_df,
+                self.similar_stops,
+                left_on=f"{order}_stop_id",
+                right_on="similar_stop_id"
+            )
+            path_freq_df.rename(columns={
+                "similar_stop_name": f"{order}_stop_name",
+                "similar_stops_centroid": f"{order}_similar_stops_centroid"
+            }, inplace=True)
+            path_freq_df.drop(columns="similar_stop_id", inplace=True)
 
-        # aggregate path-frequency
-        path_frequency = (
-            stop_times_df[["similar_stop_id", "path_id"]]
-            .groupby("path_id")
-            .count()
-            .reset_index()
+        path_freq_df = pd.merge(
+            path_freq_df,
+            self.gtfs.agency[["agency_id", "agency_name"]],
+            on="agency_id"
         )
-        path_frequency.columns = ["path_id", "path_count"]
-        path_data = pd.merge(
-            path_frequency,
-            stop_times_df.drop_duplicates(subset="path_id"),
-            on="path_id",
-        )
-        path_data_dict = path_data.to_dict(orient="records")
-
+        # convert to features
+        path_freq_dict = path_freq_df.to_dict(orient="records")
         return [
             {
                 "type": "Feature",
@@ -378,7 +284,7 @@ class Aggregator:
                     ),
                 },
                 "properties": {
-                    "frequency": path["path_count"],
+                    "frequency": path["frequency"],
                     "prev_stop_id": path["prev_stop_id"],
                     "prev_stop_name": path["prev_stop_name"],
                     "next_stop_id": path["next_stop_id"],
@@ -387,10 +293,11 @@ class Aggregator:
                     "agency_name": path["agency_name"],
                 },
             }
-            for path in path_data_dict
+            for path in path_freq_dict
         ]
-
-    def __get_trips_on_a_date(self, yyyymmdd: str):
+    
+    @staticmethod
+    def __get_trips_on_a_date(gtfs, yyyymmdd: str):
         """
         get trips are on service on a date.
 
@@ -408,26 +315,26 @@ class Aggregator:
         )
 
         # filter services by calendar
-        if self.gtfs.calendar is None:
+        if gtfs.calendar is None:
             # generate an empty series if calendar.txt is missing because it is not required.
             service_ids_on = pd.Series(name="service_id", dtype=str)
         else:
-            self.gtfs.calendar = self.gtfs.calendar.astype(
+            calendar = gtfs.calendar.astype(
                 {"start_date": int, "end_date": int}
             )
-            self.gtfs.calendar = self.gtfs.calendar[
-                self.gtfs.calendar[day_of_week] == "1"
+            calendar = calendar[
+                calendar[day_of_week] == "1"
             ]
-            self.gtfs.calendar = self.gtfs.calendar.query(
+            calendar = calendar.query(
                 f"start_date <= {int(yyyymmdd)} and {int(yyyymmdd)} <= end_date",
                 engine="python",
             )
-            service_ids_on = self.gtfs.calendar["service_id"]
+            service_ids_on = calendar["service_id"]
 
         # filter services by dates
-        if self.gtfs.calendar_dates is not None:
-            filtered = self.gtfs.calendar_dates[
-                self.gtfs.calendar_dates["date"] == yyyymmdd
+        if gtfs.calendar_dates is not None:
+            filtered = gtfs.calendar_dates[
+                gtfs.calendar_dates["date"] == yyyymmdd
             ][["service_id", "exception_type"]]
             to_be_removed_service_ids = filtered[filtered["exception_type"] == "2"][
                 "service_id"
@@ -442,8 +349,23 @@ class Aggregator:
             service_ids_on = pd.concat([service_ids_on, to_be_appended_services_ids])
 
         # filter trips
-        trips_in_services = self.gtfs.trips[
-            self.gtfs.trips["service_id"].isin(service_ids_on)
+        trips_in_services = gtfs.trips[
+            gtfs.trips["service_id"].isin(service_ids_on)
         ]
 
         return trips_in_services["trip_id"]
+
+    def read_stop_relations(self) -> list:
+        stop_relation_df = pd.merge(
+            self.stop_relations,
+            self.gtfs.stops[["stop_id", "stop_name"]],
+            on="stop_id"
+        )
+        stop_relation_df = pd.merge(
+            stop_relation_df,
+            self.similar_stops,
+            on="similar_stop_id",
+        )
+        stop_relation_df = stop_relation_df.reindex(columns=["stop_id", "stop_name",
+                                                             "similar_stop_id", "similar_stop_name"])
+        return stop_relation_df.to_dict(orient="records")

--- a/gtfs_parser/aggregate.py
+++ b/gtfs_parser/aggregate.py
@@ -243,13 +243,9 @@ class Aggregator:
         Returns:
             [type]: [description]
         """
-        # sort similar stop sequence
-        stop_times_df = (
-            self.stop_times[["trip_id", "stop_sequence", "stop_id"]]
-            .sort_values(["trip_id", "stop_sequence"])
-        )
+        #
         stop_times_df = pd.merge(
-            stop_times_df,
+            self.stop_times[["trip_id", "stop_sequence", "stop_id"]],
             self.stop_relations,
             on="stop_id"
         )
@@ -264,6 +260,8 @@ class Aggregator:
             trip_agency_df,
             on="trip_id"
         )
+        stop_times_df = stop_times_df.sort_values(["trip_id", "stop_sequence"])
+
         # generate path by joining next stop_times
         stop_times_df["next_stop_id"] = stop_times_df["similar_stop_id"].shift(-1)
         stop_times_df["next_trip_id"] = stop_times_df["trip_id"].shift(-1)

--- a/gtfs_parser/aggregate.py
+++ b/gtfs_parser/aggregate.py
@@ -134,7 +134,7 @@ class Aggregator:
         else:
             # unify by distance
             if len(delimited_id_pair) > 0:
-                undelimited_stops = solo_stops[solo_stops["stop_id"] != delimited_id_pair["stop_id"]]
+                undelimited_stops = solo_stops[~solo_stops["stop_id"].isin(delimited_id_pair["stop_id"])]
             else:
                 undelimited_stops = solo_stops
             near_id_pair = Aggregator.__calc_near_id_pair(undelimited_stops, max_distance_degree)

--- a/gtfs_parser/gtfs.py
+++ b/gtfs_parser/gtfs.py
@@ -19,6 +19,8 @@ def load_df(f: io.BufferedIOBase, table_name: str) -> pd.DataFrame:
         df["stop_lat"] = df["stop_lat"].astype(float)
         if "parent_station" not in df:
             df["parent_station"] = None
+        if "location_type" in df:
+            df["location_type"] = df["location_type"].fillna("0").astype(int)
     elif table_name == "stop_times":
         df["stop_sequence"] = df["stop_sequence"].astype(int)
 

--- a/gtfs_parser/parse.py
+++ b/gtfs_parser/parse.py
@@ -66,167 +66,117 @@ def read_routes(gtfs: GTFS, ignore_shapes=False) -> list:
     """
 
     if gtfs.shapes is None or ignore_shapes:
-        # trip-route-merge:A
-        trips_routes = pd.merge(
-            gtfs.trips[["trip_id", "route_id"]],
-            gtfs.routes[["route_id", "route_long_name", "route_short_name"]],
-            on="route_id",
-        )
-
-        # stop_times-stops-merge:B
-        stop_times_stop = pd.merge(
-            gtfs.stop_times[["stop_id", "trip_id", "stop_sequence"]],
-            gtfs.stops[["stop_id", "stop_lon", "stop_lat"]],
-            on="stop_id",
-        )
-
-        stop_times_stop["stop_pt"] = stop_times_stop.apply(
-            lambda x: (x["stop_lon"], x["stop_lat"]), axis=1
-        )
-
-        # A-B-merge
-        merged = pd.merge(stop_times_stop, trips_routes, on="trip_id")
-        # sort by route_id, trip_id, stop_sequence
-        merged.sort_values(["route_id", "trip_id", "stop_sequence"], inplace=True)
-
-        # Point -> LineString: group by route_id and trip_id
-        lines = merged.groupby(["route_id", "trip_id"])["stop_pt"].apply(
-            lambda x: x.tolist()
-        )
-        lines = lines.drop_duplicates()
-        line_df = lines.reset_index()
-        # rename: stop_pt -> line
-        line_df.rename(columns={"stop_pt": "line"}, inplace=True)
-
-        # group by route_id into MultiLineString
-        multilines = line_df.groupby(["route_id"])["line"].apply(lambda x: x.to_list())
-        multiline_df = multilines.reset_index()
-
-        # join route_id and route_name
-        multiline_df = pd.merge(
-            multiline_df[["route_id", "line"]],
-            gtfs.routes[["route_id", "route_long_name", "route_short_name"]],
-            on="route_id",
-        )
-        multiline_df["route_name"] = multiline_df["route_long_name"].fillna(
-            ""
-        ) + multiline_df["route_short_name"].fillna("")
-
-        # to GeoJSON-Feature
-        features = [
-            {
-                "type": "Feature",
-                "geometry": {
-                    "type": "MultiLineString",
-                    "coordinates": row["line"],
-                },
-                "properties": {
-                    "route_id": row["route_id"],
-                    "route_name": row["route_name"],
-                },
-            }
-            for _, row in multiline_df.iterrows()
-        ]
-        return features
+        return __read_routes_ignore_shapes(gtfs)
     else:
-        # get_shapeids_on route
-        trips_with_shape_df = gtfs.trips[["route_id", "shape_id"]].dropna(
-            subset=["shape_id"]
-        )
-        shape_ids_on_routes = trips_with_shape_df.groupby("route_id")[
-            "shape_id"
-        ].unique()
-        shape_ids_on_routes.apply(lambda x: x.sort())
-        shape_ids_on_routes = shape_ids_on_routes.reset_index()
-        shape_ids_on_routes = shape_ids_on_routes.explode("shape_id")
+        return __read_route_shapes(gtfs)
 
-        # get shape coordinate
-        shapes_df = gtfs.shapes.copy()
-        shapes_df["shape_pt"] = shapes_df.apply(
-            lambda x: (x["shape_pt_lon"], x["shape_pt_lat"]), axis=1
-        )
-        shapes_df.sort_values(["shape_id", "shape_pt_sequence"])
-        lines = shapes_df.groupby("shape_id")["shape_pt"].apply(lambda x: x.tolist())
-        line_df = lines.reset_index()
-        line_df.rename(columns={"shape_pt": "shape_line"}, inplace=True)
 
-        # merge
-        multiline_df = pd.merge(shape_ids_on_routes, line_df, on="shape_id")
-        # group by route_id into MultiLineString
-        multiline_df = multiline_df.groupby(["route_id"])["shape_line"].apply(
-            lambda x: x.to_list()
-        )
-        multiline_df = multiline_df.reset_index()
+def __read_route_shapes(gtfs):
+    # get_shapeids_on route
+    shape_ids_on_routes = gtfs.trips[["route_id", "shape_id"]].drop_duplicates().dropna(
+        subset=["shape_id"]
+    ).sort_values(["route_id", "shape_id"])
 
-        # join routes
-        multiline_df = pd.merge(
-            multiline_df,
-            gtfs.routes[["route_id", "route_long_name", "route_short_name"]],
-            on="route_id",
-        )
+    # get shape coordinate
+    shapes_df = gtfs.shapes.copy()
+    shapes_df["shape_pt"] = list(zip(shapes_df["shape_pt_lon"], shapes_df["shape_pt_lat"]))
+    shapes_df = shapes_df.sort_values(["shape_id", "shape_pt_sequence"])
+    shape_lines = shapes_df.groupby("shape_id")["shape_pt"].apply(
+        lambda x: x.tolist()
+    ).rename("line")
 
-        # join route_names
-        multiline_df["route_name"] = multiline_df["route_long_name"].fillna(
-            ""
-        ) + multiline_df["route_short_name"].fillna("")
+    # merge
+    route_line_df = pd.merge(shape_ids_on_routes, shape_lines, on="shape_id")
+    route_lines = route_line_df.set_index("route_id")["line"]
 
-        # to GeoJSON-Feature
-        features = [
-            {
-                "type": "Feature",
-                "geometry": {
-                    "type": "MultiLineString",
-                    "coordinates": row["shape_line"],
-                },
-                "properties": {
-                    "route_id": row["route_id"],
-                    "route_name": row["route_name"],
-                },
-            }
-            for _, row in multiline_df.iterrows()
-        ]
+    features = __route_lines_to_features(route_lines, gtfs.routes)
 
-        # load shapes unloaded yet
-        unloaded_shapes = gtfs.shapes[
-            ~gtfs.shapes["shape_id"].isin(shape_ids_on_routes["shape_id"].unique())
-        ]
+    # load shapes unloaded yet
+    unloaded_shape_lines = shape_lines[
+        ~shape_lines.index.isin(shape_ids_on_routes["shape_id"].unique())
+    ]
+    if len(unloaded_shape_lines) > 0:
+        # fill id, name with shape_id, line to multiline
+        multiline_df = pd.DataFrame({
+            "route_id": None,
+            "route_name": unloaded_shape_lines.index,
+            "multiline": unloaded_shape_lines.apply(lambda x: [x])
+        })
 
-        if len(unloaded_shapes) > 0:
-            unloaded_shapes["shape_pt"] = unloaded_shapes.apply(
-                lambda x: (x["shape_pt_lon"], x["shape_pt_lat"]), axis=1
-            )
-            # group by shape_id into LineString
-            unloaded_shapes = unloaded_shapes.groupby("shape_id")["shape_pt"].apply(
-                lambda x: x.tolist()
-            )
-            unloaded_shapes = unloaded_shapes.reset_index()
-            unloaded_shapes.rename(columns={"shape_pt": "shape_line"}, inplace=True)
+        unloaded_features = __route_multiline_df_to_features(multiline_df)
+        features.extend(unloaded_features)
+    return features
 
-            # group by route_id into MultiLineString
-            unloaded_shapes = unloaded_shapes.groupby(["shape_id"])["shape_line"].apply(
-                lambda x: x.to_list()
-            )
-            unloaded_shapes = unloaded_shapes.reset_index()
 
-            # fill id, name with shape_id
-            unloaded_shapes["route_id"] = None
-            unloaded_shapes["route_name"] = unloaded_shapes["shape_id"]
+def __read_routes_ignore_shapes(gtfs):
+    # generate stop patterns
+    sorted_stop_times = gtfs.stop_times.sort_values(["trip_id", "stop_sequence"])
+    trip_stop_pattern = sorted_stop_times.groupby("trip_id")["stop_id"].agg(tuple).rename("stop_pattern")
 
-            # to GeoJSON-Feature
-            unloaded_features = [
-                {
-                    "type": "Feature",
-                    "geometry": {
-                        "type": "MultiLineString",
-                        "coordinates": row["shape_line"],
-                    },
-                    "properties": {
-                        "route_id": row["route_id"],
-                        "route_name": row["route_name"],
-                    },
-                }
-                for _, row in unloaded_shapes.iterrows()
-            ]
-            features.extend(unloaded_features)
+    # unique stop pattens by route_id
+    route_trip_stop_pattern = pd.merge(
+        trip_stop_pattern,
+        gtfs.trips[["trip_id", "route_id"]],
+        on='trip_id'
+    )
+    route_stop_patterns = route_trip_stop_pattern[["route_id", "stop_pattern"]].drop_duplicates()
 
-        return features
+    # explode stop patterns to stop ids
+    route_stop_patterns["stop_id"] = route_stop_patterns["stop_pattern"]
+    route_stop_ids = route_stop_patterns.explode("stop_id")
+
+    # append geometry to stops
+    stop_geoms = pd.Series(
+        data=zip(gtfs.stops["stop_lon"], gtfs.stops["stop_lat"]),
+        name="stop_pt",
+        index=gtfs.stops["stop_id"]
+    )
+
+    # join geomtry to route stops
+    route_stop_ids["order"] = range(len(route_stop_ids))
+    route_stop_geoms = pd.merge(
+        route_stop_ids,
+        stop_geoms,
+        on="stop_id",
+    ).sort_values("order")
+
+    # Point -> LineString: group by route_id and stop_pattern
+    route_lines = route_stop_geoms.groupby(["route_id", "stop_pattern"])["stop_pt"].agg(list)
+    return __route_lines_to_features(route_lines, gtfs.routes)
+
+
+def __route_lines_to_features(route_lines, routes):
+    # group by route_id into MultiLineString
+    multilines = route_lines.groupby(['route_id']).apply(
+        lambda x: x.tolist()
+    ).rename("multiline")
+    # join route_id and route_name
+    multiline_df = pd.merge(
+        multilines,
+        routes[["route_id", "route_long_name", "route_short_name"]],
+        on="route_id",
+    )
+    multiline_df["route_name"] = multiline_df["route_long_name"].fillna(
+        ""
+    ) + multiline_df["route_short_name"].fillna("")
+
+    return __route_multiline_df_to_features(multiline_df)
+
+
+def __route_multiline_df_to_features(multiline_df):
+    dicts = multiline_df.to_dict(orient="records")
+    features = [
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "MultiLineString",
+                "coordinates": row["multiline"],
+            },
+            "properties": {
+                "route_id": row["route_id"],
+                "route_name": row["route_name"],
+            },
+        }
+        for row in dicts
+    ]
+    return features

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -1,25 +1,212 @@
 from gtfs_parser.aggregate import Aggregator
 
 
-def test_read_interpolated_stops(gtfs):
-    aggregator = Aggregator(gtfs)
-    interpolated_stops_features = aggregator.read_interpolated_stops()
-
-    # as_unify means near and similar named stops move into same lat-lon(centroid of them)
-    assert 518 == len(interpolated_stops_features)
-
-    # read_interpolated_stops unify stops having same lat-lon into one featrure.
-    # there are no stops having same lat-lon in fixture
-    aggregator_nounify = Aggregator(gtfs, no_unify_stops=True)
-    nounify_features = aggregator_nounify.read_interpolated_stops()
-    assert 899 == len(nounify_features)
+def is_coordinate_close(ref_coord, tgt_coord):
+    e = 0.000001
+    return ref_coord[0] - e <= tgt_coord[0] <= ref_coord[0] + e \
+           and ref_coord[1] - e <= tgt_coord[1] <= ref_coord[1] + e
 
 
-def test_read_route_frequency(gtfs):
-    # unify some 'similar' stops into same position, this decrease num of route_frequency features
-    aggregator = Aggregator(gtfs)
-    assert 918 == len(aggregator.read_route_frequency())
+def is_geometry_close(ref, tgt):
+    geom_type = ref["type"]
+    if geom_type != tgt["type"]:
+        return False
+    elif geom_type == "Point":
+        return is_coordinate_close(ref["coordinates"], tgt["coordinates"])
+    elif geom_type == "LineString":
+        return all(is_coordinate_close(r, t) for r, t in zip(ref["coordinates"], tgt["coordinates"]))
+    elif geom_type == "MultiLineString":
+        for line_ref, line_tgt in zip(ref["coordinates"], tgt["coordinates"]):
+            if all(is_coordinate_close(r, t) for r, t in zip(line_ref, line_tgt)):
+                return True
+    return False
 
-    # each route_frequency feature is drawn between 2 stops
-    aggregator_nounify = Aggregator(gtfs, no_unify_stops=True)
-    assert 956 == len(aggregator_nounify.read_route_frequency())
+
+def feature_exists(reference, features):
+    ref_properties = reference["properties"]
+    for feature in features:
+        tgt_property = feature["properties"]
+        if all(tgt_property.get(key) == value for key, value in ref_properties.items()):
+            if "geometry" in reference:
+                return is_geometry_close(reference.get("geometry"), feature["geometry"])
+            else:
+                return True
+    return False
+
+
+def properties_exists(reference, properties):
+    for tgt_property in properties:
+        if all(tgt_property.get(key) == value for key, value in reference.items()):
+            return True
+    return False
+
+
+def test_no_unify(gtfs):
+    aggregator = Aggregator(gtfs, yyyymmdd="20210721", no_unify_stops=True)
+
+    # The number of stops is reduced by the parent stop, rather than the number on stops.txt
+    relations = aggregator.read_stop_relations()
+    assert 896 == len(relations)
+
+    stop_features = aggregator.read_interpolated_stops()
+    assert 896 == len(stop_features)
+
+    route_features = aggregator.read_route_frequency()
+    assert 954 == len(route_features)
+
+    assert feature_exists({
+        "properties" : {
+            "frequency": 33,
+            "prev_stop_id": "1000_02",
+            "prev_stop_name": "帯広駅バスターミナル",
+            "next_stop_id": "1001_01",
+            "next_stop_name": "駅北11丁目",
+            "agency_id": "8460101001629",
+            "agency_name": "北海道拓殖バス株式会社",
+        },
+        "geometry": {
+            "type": "LineString",
+            "coordinates": [(143.203641761905, 42.9181203333334), (143.202304, 42.919629)]
+        }
+    }, route_features)
+
+
+def test_unify_no_delimiter(gtfs):
+    aggregator = Aggregator(gtfs, yyyymmdd="20210721")
+
+    relations = aggregator.read_stop_relations()
+    assert 896 == len(relations)
+
+    # They are close and have same name, but have different id prefix.
+    assert properties_exists({
+        "stop_id": "9157_01",
+        "stop_name": "緑陽台公園前",
+        "similar_stop_id": "2309_01",
+        "similar_stop_name": "緑陽台公園前"
+    }, relations)
+
+    # This stop has same name stops, but they have different id prefix and are far from it.
+    assert properties_exists({
+        "stop_id": "9159_01",
+        "stop_name": "緑陽台南区",
+        "similar_stop_id": "9159_01",
+        "similar_stop_name": "緑陽台南区"
+    }, relations)
+
+    # unify some 'similar' stops into same position,
+    # this decrease num of read_interpolated_stops, route_frequency features.
+    stop_features = aggregator.read_interpolated_stops()
+    assert 519 == len(stop_features)
+
+    assert properties_exists({
+        "properties": {
+            "similar_stop_id": "2309_01",
+            "similar_stop_name": "緑陽台公園前",
+            "count": 60,
+        },
+        "geometry": {
+            "type": "Point",
+            "coordinates": [143.19664133361098, 42.96935276793033]
+        }
+    }, stop_features)
+
+    route_features = aggregator.read_route_frequency()
+    assert 916 == len(route_features)
+
+    assert feature_exists({
+        "properties" : {
+            "frequency": 171,
+            "prev_stop_id": "1002_02",
+            "prev_stop_name": "かじのビル前",
+            "next_stop_id": "1000_親",
+            "next_stop_name": "帯広駅バスターミナル",
+            "agency_id": "8460101001629",
+            "agency_name": "北海道拓殖バス株式会社",
+        },
+        "geometry": {
+            "type": "LineString",
+            "coordinates": [(143.202401000868, 42.9208138405135), (143.203424111165, 42.9183318330811)]
+        }
+    }, route_features)
+
+
+def test_unify_delimiter(gtfs):
+    aggregator = Aggregator(gtfs, yyyymmdd="20210721", delimiter="_")
+
+    relations = aggregator.read_stop_relations()
+    assert 896 == len(relations)
+
+    # They are close and have same name, but have different id prefix.
+    assert properties_exists({
+        "stop_id": "9157_01",
+        "stop_name": "緑陽台公園前",
+        "similar_stop_id": "9157",
+        "similar_stop_name": "緑陽台公園前"
+    }, relations)
+
+    # Compared to the case of no_delimiter, the number of stops is increased
+    # by the number of stops that have same names but different id prefixes.
+    stop_features = aggregator.read_interpolated_stops()
+    assert 559 == len(stop_features)
+
+    assert properties_exists({
+        "properties": {
+            "similar_stop_id": "2309",
+            "similar_stop_name": "緑陽台公園前",
+            "count": 57,
+        },
+        "geometry": {
+            "type": "Point",
+            "coordinates": [143.1966675, 42.9692865]
+        }
+    }, stop_features)
+
+    route_features = aggregator.read_route_frequency()
+    assert 931 == len(route_features)
+
+    assert feature_exists({
+        "properties" : {
+            "frequency": 171,
+            "prev_stop_id": "1002",
+            "prev_stop_name": "かじのビル前",
+            "next_stop_id": "1000_親",
+            "next_stop_name": "帯広駅バスターミナル",
+            "agency_id": "8460101001629",
+            "agency_name": "北海道拓殖バス株式会社",
+        },
+        "geometry": {
+            "type": "LineString",
+            "coordinates": [(143.202401000868, 42.9208138405135), (143.203424111165, 42.9183318330811)]
+        }
+    }, route_features)
+
+
+def test_unify_delimiter_night(gtfs):
+    # Specifying time reduces the number of route_frequency.
+    aggregator = Aggregator(gtfs, yyyymmdd="20210721", delimiter="_", begin_time="200000", end_time="270000")
+
+    stop_features = aggregator.read_interpolated_stops()
+    assert 559 == len(stop_features)
+
+    relations = aggregator.read_stop_relations()
+    assert 896 == len(relations)
+
+    route_features = aggregator.read_route_frequency()
+    assert 293 == len(route_features)
+
+    assert feature_exists({
+        "properties" : {
+            "frequency": 11,
+            "prev_stop_id": "1002",
+            "prev_stop_name": "かじのビル前",
+            "next_stop_id": "1000_親",
+            "next_stop_name": "帯広駅バスターミナル",
+            "agency_id": "8460101001629",
+            "agency_name": "北海道拓殖バス株式会社",
+        },
+        "geometry": {
+            "type": "LineString",
+            "coordinates": [(143.202401000868, 42.9208138405135), (143.203424111165, 42.9183318330811)]
+        }
+    }, route_features)
+


### PR DESCRIPTION
### Close Issues
* #1 
* #5
* MIERUNE/GTFS-GO#77

### Benchmark
![image](https://github.com/MIERUNE/gtfs-parser/assets/48475419/f820a0bd-2676-4bc1-8f5b-cfe600dfc9f7)

#### data set
| name | source | size | file |
| ---- | ---- | ---- | ---- |
| Takushoku Bus | the fixture of test | small | [fx_TakushokuBus.zip](https://github.com/MIERUNE/gtfs-parser/files/15213416/fx_TakushokuBus.zip) |
| Tokyo Toei Bus | #6 | medium | [P6_ToeiBus.zip](https://github.com/MIERUNE/gtfs-parser/files/15213419/P6_ToeiBus.zip) |
| Vancouver TransLink | MIERUNE/GTFS-GO#77 | large | [G77_TransLink.zip](https://github.com/MIERUNE/gtfs-parser/files/15213418/G77_TransLink.zip)
| Swiss | #1 | extra large | [GTFS_FP2021_2021-12-08_09-10.zip](https://opentransportdata.swiss/dataset/1aff176a-9665-4395-a3b1-03e3032a0373/resource/f587c0fb-e410-4fd2-a468-4f6c4c40a049/download/gtfs_fp2021_2021-12-08_09-10.zip)

#### results
* read_stops(): 1.2 - 1.7 times faster
* read_routes() noshape: 8.0 - 12.7 times faster
* read_routes() shape: 4.1 - 6.6 times faster 
* aggregator nounify: 2.9 - 3.9 times faster 
* aggregator unify: 21.0 - 37.2 times faster 

#### remarks
Current read_routes()@parse.py has 2 bugs. I fix them temporary and use for measurement.
Like this:
```
        # Point -> LineString: group by route_id and trip_id
        lines = merged.groupby(["route_id", "trip_id"])["stop_pt"].apply(tuple)
        line_df = lines.reset_index()[["route_id", "stop_pt"]].drop_duplicates()
```

### Description（変更内容）
#### Accelerate and refactor for aggregation, especially for stop unification 
* Change the unification from apply per stops to process for whole dataframe.
* Change merge procedures so that they are done on smaller dataframes.
* Decrease `max_distance_degree` 0.01 to 0.003 and add process of join near groups.
  * This change reduces the number of unified stops in test cases because there are stops with a same name that are 400 meters apart from each other.
* Exclude parent stops from aggregation with no_unify_stops option. 
  * This change reduces the number of aggregated stops in the test case with no_unify_stops option.
* Break large `__aggregate_similar_stops()` into small static methods. 
* Remove path_id and related procedures in `read_route_frequency()`

#### Add read_stop_relations() to Aggregator
* Add `read_stop_relations() ` that returns relations of stops and similar stops as a list of dictionaries.
* Eliminate modification of gtfs data frames in the Aggregator class.
* Eliminate GTFS-GO (gtfs_go_dialog.py) getting stop relations from inside Aggregator.
 
#### Acclerate and refactor read_routes()
* Unify stop patterns by stop_id, not by line string.
* Minimize number of coordinate pairing and linestring generation.
* Fix sort procedure for stop sequence.
  *  The route collapse problem in PR #9 was caused by a difference in sorting behavior between Pandas 2.2 and 1.1 (built into QGIS 3.28).
* Change the method of generating features from iterrows() to to_dict().
* Break large `read_routes()` into some small methods. 

#### Acclerate read_stops()
* Change merge/join procedure to be faster.
* Change the method of generating features from iterrows() to to_dict().

#### Add test cases for aggregation
* Add test cases of delimiter, time filter.
* Add tests for record values.
* Set target date to feed_start_date.
* Arrange the test cases from per-method to per-option.

### Manual Testing（手動テスト）
<!-- If manual testing is required, please describe the procedure. -->
<!-- 手動での動作確認が必要なら、そのやり方を記述してください。-->

Please check in QGIS on your Mac OS.