### PR TITLE
Skip unused files

### DIFF
--- a/tests/test_gtfs.py
+++ b/tests/test_gtfs.py
@@ -12,23 +12,13 @@ def test_gtfs():
 
     # required tables
     assert isinstance(gtfs.agency, pd.DataFrame)
-    assert isinstance(gtfs.calendar, pd.DataFrame)
     assert isinstance(gtfs.routes, pd.DataFrame)
     assert isinstance(gtfs.stop_times, pd.DataFrame)
     assert isinstance(gtfs.stops, pd.DataFrame)
     assert isinstance(gtfs.trips, pd.DataFrame)
 
     # optional but in fixture
-    assert isinstance(gtfs.fare_attributes, pd.DataFrame)
-    assert isinstance(gtfs.fare_rules, pd.DataFrame)
     assert isinstance(gtfs.feed_info, pd.DataFrame)
-    assert isinstance(gtfs.office_jp, pd.DataFrame)
     assert isinstance(gtfs.shapes, pd.DataFrame)
-    assert isinstance(gtfs.translations, pd.DataFrame)
+    assert isinstance(gtfs.calendar, pd.DataFrame)
     assert isinstance(gtfs.calendar_dates, pd.DataFrame)
-
-    # optional but not in fixture
-    assert gtfs.agency_jp is None
-    assert gtfs.frequencies is None
-    assert gtfs.routes_jp is None
-    assert gtfs.transfers is None


### PR DESCRIPTION
I suggest not loading unused files to avoid extra errors and performance loss.

### Close Issues
* #12 

### Description（変更内容）
* Remove GTFS data class members unused in gtfs-parser.
* Skip reading unused files.
* Fix the test for GTFS class.

### Manual Testing（手動テスト）
Please test reading [GTFS of Nanto city](https://github.com/MIERUNE/gtfs-parser/files/15213811/feed_nantocity_nanbus_20240322_092043.zip)

### Remarks
`test_parser.py` failed because of bugs in read_routes().
This failure is not related to this PR.
I fixed them by PR #11 